### PR TITLE
Fix python exec endpoint routing

### DIFF
--- a/api/py/exec.py
+++ b/api/py/exec.py
@@ -91,7 +91,10 @@ def execute_python(code, inputs=None):
 # -------- Flask app for Vercel --------
 app = Flask(__name__)
 
+# Support both root and full path when deployed so that requests to
+# `/api/py/exec` on Vercel reach this handler without returning 404.
 @app.post("/")
+@app.post("/api/py/exec")
 def run():
     body = request.get_json(silent=True) or {}
     code = body.get("code", "")


### PR DESCRIPTION
## Summary
- handle requests to `/api/py/exec` without returning 404 by registering both root and full path

## Testing
- `python -m py_compile api/py/exec.py`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c10192eec08333824d884798583b41