### PR TITLE
Handle threading signal limitation in Python exec module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 .env
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
- Guard signal usage so alarms are only set on the main thread, preventing ValueError in threaded environments
- Ignore Python cache directories and bytecode files

## Testing
- `python -m py_compile api/py/exec.py`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1034de4d88333bd55c38d03787d93