### PR TITLE
Fix math solver typing and Tailwind badge colors

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -35,18 +35,18 @@
   }
   
   .badge-success {
-    @apply badge bg-success-100 text-success-800;
+    @apply badge bg-success-100 text-success-600;
   }
-  
+
   .badge-warning {
-    @apply badge bg-warning-100 text-warning-800;
+    @apply badge bg-warning-100 text-warning-600;
   }
-  
+
   .badge-error {
-    @apply badge bg-error-100 text-error-800;
+    @apply badge bg-error-100 text-error-600;
   }
-  
+
   .badge-info {
-    @apply badge bg-primary-100 text-primary-800;
+    @apply badge bg-primary-100 text-primary-700;
   }
 }

--- a/src/services/math-solver.ts
+++ b/src/services/math-solver.ts
@@ -234,7 +234,10 @@ CRITICAL: Return ONLY valid JSON - no markdown, no explanations.`
     
     let finalAnswer = result.answer;
     let finalConfidence = result.confidence || 0.5;
-    let pythonResult = { ok: false, error: 'No Python code' };
+    let pythonResult: Awaited<ReturnType<typeof runPython>> = {
+      ok: false,
+      error: 'No Python code'
+    };
     
     // Execute Python code if provided
     if (result.python_code) {


### PR DESCRIPTION
## Summary
- Align math solver's Python result typing with `runPython`
- Replace nonexistent Tailwind color classes with valid shades

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c37d496e988333abc03a4dc02255c9