### PR TITLE
Ensure concurrent math models execute in SAT solver

### DIFF
--- a/src/services/math-solver.ts
+++ b/src/services/math-solver.ts
@@ -56,98 +56,38 @@ export class MathSolver {
 
   async solve(item: RoutedItem): Promise<SolverResult> {
     const startTime = Date.now();
-    const timeoutMs = 45000; // 45s total timeout for speed
-    console.log(`🔄 Math solver starting concurrent trio with early return (${timeoutMs}ms timeout)...`);
-    
+    const timeoutMs = 60000; // 60s overall budget
+    console.log(`🔄 Math solver starting concurrent trio (${timeoutMs}ms overall)...`);
+
     try {
-      // Dispatch all three models concurrently with aggressive timeouts
-      const individualTimeout = Math.min(timeoutMs * 0.7, 35000); // 70% of total timeout, max 35s
-      
-      // Return as soon as we get 2+ successful results OR all complete OR timeout
-      const results = await this.raceForResults(item, individualTimeout, timeoutMs);
-      
+      // Dispatch all three models concurrently
+      const individualTimeout = Math.min(timeoutMs - 5000, 55000); // leave buffer for aggregation
+
+      const results = await this.runConcurrentModels(item, individualTimeout);
       console.log(`🔄 Math models completed: ${results.length}/${MATH_MODELS.length} successful`);
-      
+
       if (results.length === 0) {
         throw new Error('All Math models failed');
       }
-      
+
       // Select best result based on Python verification and consensus
       const bestResult = await this.selectBestMathResult(results);
-      
+
       console.log(`✅ Math solved: ${bestResult.final} (${bestResult.confidence.toFixed(2)}) in ${Date.now() - startTime}ms`);
       return bestResult;
-      
+
     } catch (error) {
       console.error('Math solver error:', error);
       throw error;
     }
   }
-  
-  private async raceForResults(item: RoutedItem, individualTimeout: number, totalTimeout: number): Promise<SolverResult[]> {
-    const results: SolverResult[] = [];
-    const promises = MATH_MODELS.map((model, index) => 
-      this.solveWithModelSafe(item, model, individualTimeout).then(result => ({
-        result,
-        index,
-        model
-      }))
-    );
-    
-    return new Promise((resolve, reject) => {
-      let completed = 0;
-      let hasResolved = false;
-      
-      // Overall timeout
-      const timeoutId = setTimeout(() => {
-        if (!hasResolved) {
-          hasResolved = true;
-          if (results.length > 0) {
-            console.log(`⏱️ Math timeout with ${results.length} results, proceeding...`);
-            resolve(results);
-          } else {
-            reject(new Error('Math total timeout with no results'));
-          }
-        }
-      }, totalTimeout);
-      
-      promises.forEach(promise => {
-        promise.then(({ result }) => {
-          if (!hasResolved && result.confidence > 0.15) { // Filter out obvious fallbacks
-            results.push(result);
-            console.log(`✅ Math ${result.model} completed: ${result.final} (${result.confidence.toFixed(2)})`);
-            
-            // Return early if we have 2+ good results (especially with Python verification)
-            const pythonVerified = results.filter(r => r.meta.pythonResult?.ok).length;
-            if ((pythonVerified >= 2) || 
-                (results.length >= 2 && results.some(r => r.confidence > 0.8)) ||
-                results.length >= 3) {
-              hasResolved = true;
-              clearTimeout(timeoutId);
-              console.log(`🚀 Math early return with ${results.length} results (${pythonVerified} Python verified)`);
-              resolve(results);
-              return;
-            }
-          }
-          
-          completed++;
-          // If all models completed, return what we have
-          if (completed >= MATH_MODELS.length && !hasResolved) {
-            hasResolved = true;
-            clearTimeout(timeoutId);
-            resolve(results);
-          }
-        }).catch(error => {
-          console.warn(`Math model failed:`, error);
-          completed++;
-          if (completed >= MATH_MODELS.length && !hasResolved) {
-            hasResolved = true;
-            clearTimeout(timeoutId);
-            resolve(results);
-          }
-        });
-      });
-    });
+
+  private async runConcurrentModels(item: RoutedItem, timeoutMs: number): Promise<SolverResult[]> {
+    const promises = MATH_MODELS.map(model => this.solveWithModelSafe(item, model, timeoutMs));
+    const settled = await Promise.allSettled(promises);
+    return settled
+      .filter((r): r is PromiseFulfilledResult<SolverResult> => r.status === 'fulfilled')
+      .map(r => r.value);
   }
 
   private async solveWithModelSafe(item: RoutedItem, model: string, timeoutMs: number): Promise<SolverResult> {


### PR DESCRIPTION
## Summary
- run GPT-5, Grok-4, and Qwen math models in parallel using `Promise.allSettled`
- increase overall math timeout to 60s with larger per-model budgets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c383d8afa883338d7341bd46b50e33