### PR TITLE
feat: add manual section toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Brain, Zap, Target } from 'lucide-react';
 import { QuestionInput } from './components/QuestionInput';
 import { SolutionDisplay } from './components/SolutionDisplay';
 import { SATEngine } from './services/sat-engine-v2';
-import { AggregatedAnswer } from './types/sat';
+import { AggregatedAnswer, Section } from './types/sat';
 
 const satEngine = new SATEngine();
 
@@ -12,16 +12,17 @@ function App() {
   const [isLoading, setIsLoading] = useState(false);
 
   const handleQuestionSubmit = async (
-    imageBase64: string, 
-    ocrText: string, 
-    choices: string[], 
+    imageBase64: string,
+    ocrText: string,
+    choices: string[],
+    section: Section,
     correctAnswer?: string
   ) => {
     setIsLoading(true);
     setSolution(null);
 
     try {
-      const result = await satEngine.solveQuestion(imageBase64, ocrText, choices, correctAnswer);
+      const result = await satEngine.solveQuestion(imageBase64, ocrText, choices, section, correctAnswer);
       setSolution(result);
     } catch (error) {
       console.error('Error solving question:', error);

--- a/src/components/QuestionInput.tsx
+++ b/src/components/QuestionInput.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { Send, Image } from 'lucide-react';
 import { ImageUpload } from './ImageUpload';
+import { Section } from '../types/sat';
 
 interface QuestionInputProps {
-  onSubmit: (imageBase64: string, ocrText: string, choices: string[], correctAnswer?: string) => void;
+  onSubmit: (imageBase64: string, ocrText: string, choices: string[], section: Section, correctAnswer?: string) => void;
   isLoading: boolean;
 }
 
@@ -12,6 +13,7 @@ export const QuestionInput: React.FC<QuestionInputProps> = ({ onSubmit, isLoadin
   const [ocrText, setOcrText] = useState('');
   const [choices, setChoices] = useState(['', '', '', '']);
   const [questionType, setQuestionType] = useState<'multiple-choice' | 'grid-in'>('multiple-choice');
+  const [section, setSection] = useState<Section>('EBRW');
   const [isProcessingImage, setIsProcessingImage] = useState(false);
   const [hasProcessedImage, setHasProcessedImage] = useState(false);
 
@@ -22,7 +24,7 @@ export const QuestionInput: React.FC<QuestionInputProps> = ({ onSubmit, isLoadin
       ? choices.filter(choice => choice.trim()) 
       : [];
     
-    onSubmit(imageBase64, ocrText, validChoices);
+    onSubmit(imageBase64, ocrText, validChoices, section);
   };
 
   const handleImageProcessed = (base64Data: string, questionText: string, extractedChoices: string[]) => {
@@ -94,6 +96,27 @@ export const QuestionInput: React.FC<QuestionInputProps> = ({ onSubmit, isLoadin
               ))}
             </div>
           )}
+
+          <div className="flex gap-4 pt-2">
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                className="text-primary-600"
+                checked={section === 'EBRW'}
+                onChange={() => setSection('EBRW')}
+              />
+              EBRW
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                className="text-primary-600"
+                checked={section === 'MATH'}
+                onChange={() => setSection('MATH')}
+              />
+              Math
+            </label>
+          </div>
 
           <div className="pt-4 border-t border-slate-200">
             <button

--- a/src/services/router.ts
+++ b/src/services/router.ts
@@ -19,16 +19,16 @@ If the prompt is text-only (including OCR), set has_figure to false.`;
 export class SATRouter {
   constructor() {}
 
-  async routeItem(inputItem: SatItem): Promise<RoutedItem> {
+  async routeItem(inputItem: SatItem, providedSection?: Section): Promise<RoutedItem> {
     console.log('📍 SATRouter starting classification...');
-    
+
     const text = inputItem.promptText || '';
     const isGridIn = inputItem.isGridIn || inputItem.choices.length === 0;
-    
-    // Simple heuristic-based routing
-    const section = this.classifySection(text, inputItem.choices);
+
+    // Use provided section if available, otherwise fall back to heuristic
+    const section = providedSection || this.classifySection(text, inputItem.choices);
     const subdomain = this.classifySubdomain(text, section, isGridIn);
-    
+
     const routedItem: RoutedItem = {
       section,
       subdomain,
@@ -40,7 +40,7 @@ export class SATRouter {
       isGridIn,
       hasFigure: !!inputItem.imageBase64
     };
-    
+
     console.log(`📍 Classified as: ${section}/${subdomain}${isGridIn ? ' (grid-in)' : ''}`);
     return routedItem;
   }

--- a/src/services/sat-engine-v2.ts
+++ b/src/services/sat-engine-v2.ts
@@ -1,4 +1,4 @@
-import { SatItem, AggregatedAnswer, PerformanceMetrics } from '../types/sat';
+import { SatItem, AggregatedAnswer, PerformanceMetrics, Section } from '../types/sat';
 import { SATRouter } from './router';
 import { EBRWSolver } from './ebrw-solver';
 import { MathSolver } from './math-solver';
@@ -40,9 +40,10 @@ export class SATEngine {
   }
 
   async solveQuestion(
-    imageBase64: string, 
-    ocrText: string, 
-    choices: string[], 
+    imageBase64: string,
+    ocrText: string,
+    choices: string[],
+    section: Section,
     correctAnswer?: string
   ): Promise<AggregatedAnswer> {
     const startTime = Date.now();
@@ -61,7 +62,7 @@ export class SATEngine {
 
       // 2. Route the item (Router phase)
       console.log('📍 Router phase starting...');
-      const routedItem = await this.router.routeItem(inputItem);
+      const routedItem = await this.router.routeItem(inputItem, section);
       console.log(`📍 Routed as: ${routedItem.section}/${routedItem.subdomain}`);
 
       // 3. Solve based on section (Solver phase)


### PR DESCRIPTION
## Summary
- allow users to select EBRW or Math manually and pass selection through pipeline
- update SAT engine and router to respect provided section instead of classifying

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c398ccb8d08333b1ce5ebd271c9905