### PR TITLE
Promote GPT-5 to primary SAT solver model

### DIFF
--- a/src/services/ebrw-solver.ts
+++ b/src/services/ebrw-solver.ts
@@ -111,9 +111,9 @@ The chosen answer must be directly supported by your evidence list.
 Elimination notes should name a specific flaw category (see taxonomy).
 Output the JSON only.`;
 
-// EBRW solver uses OpenAI O3 Pro exclusively (transcription still provided by o4 pipeline)
+// EBRW solver uses OpenAI GPT-5 as the primary reasoning model (transcription still provided by o4 pipeline)
 const EBRW_MODELS = [
-  'openai/o3-pro'
+  'openai/gpt-5'
 ];
 
 export class EBRWSolver {
@@ -380,13 +380,13 @@ CRITICAL: Return ONLY valid JSON - no markdown, no explanations.`
       const response = await openrouterClient(primaryModel, messages, options);
       return { response, modelUsed: primaryModel };
     } catch (error) {
-      if (primaryModel === 'openai/o3-pro' && this.isVerificationFailure(error)) {
-        console.warn('⚠️ O3 Pro verification error (400). Falling back to openai/gpt-5...');
+      if (primaryModel === 'openai/gpt-5' && this.isVerificationFailure(error)) {
+        console.warn('⚠️ GPT-5 verification error (400). Falling back to anthropic/claude-4.1-sonnet...');
         try {
-          const response = await openrouterClient('openai/gpt-5', messages, options);
-          return { response, modelUsed: 'openai/gpt-5' };
+          const response = await openrouterClient('anthropic/claude-4.1-sonnet', messages, options);
+          return { response, modelUsed: 'anthropic/claude-4.1-sonnet' };
         } catch (fallbackError) {
-          console.warn('⚠️ openai/gpt-5 fallback failed after O3 Pro 400:', fallbackError);
+          console.warn('⚠️ anthropic/claude-4.1-sonnet fallback failed after GPT-5 400:', fallbackError);
           throw error;
         }
       }

--- a/src/services/llm-client.ts
+++ b/src/services/llm-client.ts
@@ -3,7 +3,6 @@ import { ModelConfig, ModelName } from '../types/sat';
 // Default configuration for models
 export const DEFAULT_MODEL_CONFIG: ModelConfig = {
   enabled_models: [
-    'openai/o3-pro',
     'openai/gpt-5',
     'x-ai/grok-4',
     'anthropic/claude-4.1-sonnet'
@@ -15,12 +14,6 @@ export const DEFAULT_MODEL_CONFIG: ModelConfig = {
 
 // Model capabilities and preferences
 export const MODEL_CAPABILITIES = {
-  'openai/o3-pro': {
-    strengths: ['reasoning', 'math', 'reading'],
-    supports_images: true,
-    context_length: 200000,
-    cost_tier: 'high'
-  },
   'openai/gpt-5': {
     strengths: ['general_reasoning', 'math', 'coding'],
     supports_images: true,
@@ -44,15 +37,15 @@ export const MODEL_CAPABILITIES = {
 export function getModelForTask(task: 'math' | 'ebrw', priority: 'speed' | 'accuracy' = 'accuracy'): ModelName[] {
   if (task === 'math') {
     if (priority === 'speed') {
-      return ['openai/o3-pro'];
+      return ['openai/gpt-5'];
     } else {
-      return ['openai/o3-pro'];
+      return ['openai/gpt-5'];
     }
   } else { // EBRW
     if (priority === 'speed') {
-      return ['openai/o3-pro'];
+      return ['openai/gpt-5'];
     } else {
-      return ['openai/o3-pro'];
+      return ['openai/gpt-5'];
     }
   }
 }

--- a/src/services/math-solver.ts
+++ b/src/services/math-solver.ts
@@ -57,9 +57,9 @@ result = sol  # or a number like Fraction(3,5) or float/int
 
 Final step: Output the JSON only.`;
 
-// Math solver now uses OpenAI O3 Pro exclusively via OpenRouter
+// Math solver now uses OpenAI GPT-5 as the primary model via OpenRouter
 const MATH_MODELS = [
-  'openai/o3-pro'
+  'openai/gpt-5'
 ];
 
 export class MathSolver {
@@ -270,13 +270,13 @@ CRITICAL: Return ONLY valid JSON - no markdown, no explanations.`
       const response = await openrouterClient(primaryModel, messages, options);
       return { response, modelUsed: primaryModel };
     } catch (error) {
-      if (primaryModel === 'openai/o3-pro' && this.isVerificationFailure(error)) {
-        console.warn('⚠️ Math solver O3 Pro verification error (400). Switching to openai/gpt-5 fallback.');
+      if (primaryModel === 'openai/gpt-5' && this.isVerificationFailure(error)) {
+        console.warn('⚠️ Math solver GPT-5 verification error (400). Switching to x-ai/grok-4 fallback.');
         try {
-          const response = await openrouterClient('openai/gpt-5', messages, options);
-          return { response, modelUsed: 'openai/gpt-5' };
+          const response = await openrouterClient('x-ai/grok-4', messages, options);
+          return { response, modelUsed: 'x-ai/grok-4' };
         } catch (fallbackError) {
-          console.warn('⚠️ Math solver fallback failed after O3 Pro 400:', fallbackError);
+          console.warn('⚠️ Math solver fallback failed after GPT-5 400:', fallbackError);
           throw error;
         }
       }

--- a/src/services/sat-engine-v2.ts
+++ b/src/services/sat-engine-v2.ts
@@ -30,7 +30,6 @@ export class SATEngine {
       p95_latency_ms: 0,
       escalation_rate: 0,
       model_usage: {
-        'openai/o3-pro': 0,
         'openai/gpt-5': 0,
         'x-ai/grok-4': 0,
         'anthropic/claude-4.1-sonnet': 0

--- a/src/types/sat.ts
+++ b/src/types/sat.ts
@@ -15,7 +15,6 @@ export type MathDomain =
   | 'geometry_trigonometry';
 
 export type ModelName =
-  | 'openai/o3-pro'
   | 'openai/gpt-5'
   | 'x-ai/grok-4'
   | 'anthropic/claude-4.1-sonnet';


### PR DESCRIPTION
## Summary
- remove OpenAI o3-pro from the model configuration and type definitions
- promote openai/gpt-5 to the primary solver across math and EBRW flows with updated fallbacks
- update metrics tracking to align with the new primary model list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a060fedc833392f64cbd70c0876b